### PR TITLE
setup.cfg: fix setuptools warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [nosetests]
 config = nose.cfg


### PR DESCRIPTION
Why:

* Warning: UserWarning: Usage of dash-separated 'description-file' wil
not be supported in future versions. Please use the underscore name
'description_file' instead